### PR TITLE
windows path compatibility

### DIFF
--- a/traktexport/__init__.py
+++ b/traktexport/__init__.py
@@ -5,15 +5,13 @@ import trakt.core  # type: ignore[import]
 # trakt is configured by modifying module-level variables
 # set those up here, is setup before any other imports
 
-operating_system = platform.system()
-home_path = path.expanduser('~')
-if operating_system in ("Linux", "Darwin"):
-    data_dir = environ.get("XDG_DATA_HOME", path.join(home_path, ".local", "share"))
-elif operating_system == "Windows":
-    data_dir = path.join(home_path, '.traktexport')
-    makedirs(data_dir, exist_ok=True)
+if "XDG_DATA_HOME" in environ:
+   data_dir = environ["XDG_DATA_HOME"]
+elif platform.system() == "Windows":
+   data_dir = path.expanduser("~/.traktexport")
 else:
-    data_dir = home_path
+   data_dir = path.expanduser("~/.local/share")
+makedirs(data_dir, exist_ok=True)
 default_cfg_path = path.join(data_dir, "traktexport.json")
 traktexport_cfg = environ.get("TRAKTEXPORT_CFG", default_cfg_path)
 trakt.core.AUTH_METHOD = trakt.core.OAUTH_AUTH

--- a/traktexport/__init__.py
+++ b/traktexport/__init__.py
@@ -1,11 +1,19 @@
-from os import environ, path
-
+from os import environ, path, makedirs
+import platform
 import trakt.core  # type: ignore[import]
 
 # trakt is configured by modifying module-level variables
 # set those up here, is setup before any other imports
 
-data_dir = environ.get("XDG_DATA_HOME", path.join(environ["HOME"], ".local", "share"))
+operating_system = platform.system()
+home_path = path.expanduser('~')
+if operating_system in ("Linux", "Darwin"):
+    data_dir = environ.get("XDG_DATA_HOME", path.join(home_path, ".local", "share"))
+elif operating_system == "Windows":
+    data_dir = path.join(home_path, '.traktexport')
+    makedirs(data_dir, exist_ok=True)
+else:
+    data_dir = home_path
 default_cfg_path = path.join(data_dir, "traktexport.json")
 traktexport_cfg = environ.get("TRAKTEXPORT_CFG", default_cfg_path)
 trakt.core.AUTH_METHOD = trakt.core.OAUTH_AUTH


### PR DESCRIPTION
This pull request add compatibility for windows. As `HOME` environment variable is not available on windows. so it uses `os.path.expanduser` for home path.